### PR TITLE
StdOut and Exception Field sizes changed to Int32.MaxValue (2Gb) meaning 1 billion chars;

### DIFF
--- a/ContinuumProcessRunner/Constants.cs
+++ b/ContinuumProcessRunner/Constants.cs
@@ -21,7 +21,7 @@ namespace ContinuumProcessRunner
         public static string DEFAULTRETCODEFIELD = "ProcessRunnerReturnCode";
         public static string DEFAULTEXCEPTIONFIELD = "ProcessRunnerException";
 
-        public static int LARGEOUTPUTFIELDSIZE = 65535;
+        public static int LARGEOUTPUTFIELDSIZE = Int32.MaxValue;
         public static int SMALLOUTPUTFIELDSIZE = 512;
     }
 }

--- a/ContinuumProcessRunner/ProcessRunnerUserControl.Designer.cs
+++ b/ContinuumProcessRunner/ProcessRunnerUserControl.Designer.cs
@@ -72,7 +72,7 @@
             this.labelVersion.Name = "labelVersion";
             this.labelVersion.Size = new System.Drawing.Size(38, 12);
             this.labelVersion.TabIndex = 1;
-            this.labelVersion.Text = "(v1.0.0)";
+            this.labelVersion.Text = "(v1.0.1)";
             // 
             // labelHeader
             // 

--- a/ReadMe.MD
+++ b/ReadMe.MD
@@ -48,7 +48,7 @@ This tool avoids the problem by using asynchronous events to listen to the outpu
 
 The input parameters are passed as command line arguments to the executable, in Alteryx column order, as Strings.  All columns are passed.
 
-The output and error columns are currently sized at 65535 characters, and the return code is a generous 512 characters.
+The output and error columns are currently sized at 1073741823 characters (Int32.MaxValue bytes, 2 bytes per char), and the return code is a generous 256 characters, considering that the code should be a single numeric digit.
 
 
 
@@ -295,3 +295,5 @@ This product is therefore the private commercial intellectual property of Contin
 ## Update History
 
 ### v1.0.0 Alpha Release
+
+### v1.0.1 Beta; Max field size for StdOut and Exception output fields increased from 65535 to 


### PR DESCRIPTION
BRANCH: 2018-08-15_LT3_MaxFieldSizeIncrease

CHANGED: ContinuumProcessRunner/Constants.cs
 - LARGEOUTPUTFIELDSIZE changed to Int32.MaxValue (2Gb)

CHANGED: ContinuumProcessRunner/ProcessRunnerUserControl.Designer.cs
 - Version label text updated.

CHANGED: ReadMe.MD
 - Text changed to detail new field sizes.
 - Update History amended accordingly.