### PR TITLE
v1.0.2 Improved performance for large output record sets;

### DIFF
--- a/ContinuumProcessRunner/AlteryxTesting/ProcessRunnerTest_HighLoad.bak
+++ b/ContinuumProcessRunner/AlteryxTesting/ProcessRunnerTest_HighLoad.bak
@@ -1,0 +1,126 @@
+<?xml version="1.0"?>
+<AlteryxDocument yxmdVer="2018.2">
+  <Nodes>
+    <Node ToolID="2">
+      <GuiSettings Plugin="AlteryxBasePluginsGui.TextInput.TextInput">
+        <Position x="54" y="54" />
+      </GuiSettings>
+      <Properties>
+        <Configuration>
+          <NumRows value="1" />
+          <Fields>
+            <Field name="ColA" />
+            <Field name="ColB" />
+          </Fields>
+          <Data>
+            <r>
+              <c>C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe</c>
+              <c>get-eventlog -logname "Application" -newest 1000 | convertto-csv</c>
+            </r>
+          </Data>
+        </Configuration>
+        <Annotation DisplayMode="0">
+          <Name />
+          <DefaultAnnotationText />
+          <Left value="False" />
+        </Annotation>
+      </Properties>
+      <EngineSettings EngineDll="AlteryxBasePluginsEngine.dll" EngineDllEntryPoint="AlteryxTextInput" />
+    </Node>
+    <Node ToolID="4">
+      <GuiSettings Plugin="AlteryxBasePluginsGui.BrowseV2.BrowseV2">
+        <Position x="354" y="54" />
+      </GuiSettings>
+      <Properties>
+        <Configuration>
+          <TempFile>C:\Users\User\AppData\Local\Temp\Engine_1296_b25fe49201894fe4a580bef021053dfb_\Engine_6712_0abb76fae635483b8740d0ea36fdfdb6_.yxdb</TempFile>
+          <TempFileDataProfiling />
+          <Layout>
+            <ViewMode>Single</ViewMode>
+            <ViewSize value="100" />
+            <View1>
+              <DefaultTab>Profile</DefaultTab>
+              <Hints>
+                <Table />
+              </Hints>
+            </View1>
+            <View2 />
+          </Layout>
+        </Configuration>
+        <Annotation DisplayMode="0">
+          <Name />
+          <DefaultAnnotationText />
+          <Left value="False" />
+        </Annotation>
+      </Properties>
+      <EngineSettings EngineDll="AlteryxBasePluginsEngine.dll" EngineDllEntryPoint="AlteryxBrowseV2" />
+    </Node>
+    <Node ToolID="5">
+      <GuiSettings Plugin="ContinuumProcessRunner.ProcessRunner">
+        <Position x="210" y="54" />
+      </GuiSettings>
+      <Properties>
+        <Configuration>
+          <ExePathField>ColA</ExePathField>
+          <StdOutField>ProcessRunnerStdOut</StdOutField>
+          <RetCodeField>ProcessRunnerReturnCode</RetCodeField>
+          <ExceptionField>ProcessRunnerException</ExceptionField>
+        </Configuration>
+        <Annotation DisplayMode="0">
+          <Name />
+          <DefaultAnnotationText>ProcessRunner</DefaultAnnotationText>
+          <Left value="False" />
+        </Annotation>
+      </Properties>
+      <EngineSettings EngineDll="ContinuumProcessRunner.dll" EngineDllEntryPoint=".Net:ContinuumProcessRunner.ProcessRunnerNetPlugin" />
+    </Node>
+  </Nodes>
+  <Connections>
+    <Connection>
+      <Origin ToolID="2" Connection="Output" />
+      <Destination ToolID="5" Connection="Input" />
+    </Connection>
+    <Connection>
+      <Origin ToolID="5" Connection="Output" />
+      <Destination ToolID="4" Connection="Input" />
+    </Connection>
+  </Connections>
+  <Properties>
+    <Memory default="True" />
+    <GlobalRecordLimit value="0" />
+    <TempFiles default="True" />
+    <Annotation on="True" includeToolName="False" />
+    <ConvErrorLimit value="10" />
+    <ConvErrorLimit_Stop value="False" />
+    <CancelOnError value="False" />
+    <DisableBrowse value="False" />
+    <EnablePerformanceProfiling value="False" />
+    <DisableAllOutput value="False" />
+    <ShowAllMacroMessages value="False" />
+    <ShowConnectionStatusIsOn value="True" />
+    <ShowConnectionStatusOnlyWhenRunning value="True" />
+    <ZoomLevel value="0" />
+    <LayoutType>Horizontal</LayoutType>
+    <MetaInfo>
+      <NameIsFileName value="True" />
+      <Name>ProcessRunnerTest_HighLoad</Name>
+      <Description />
+      <RootToolName />
+      <ToolVersion />
+      <ToolInDb value="False" />
+      <CategoryName />
+      <SearchTags />
+      <Author />
+      <Company />
+      <Copyright />
+      <DescriptionLink actual="" displayed="" />
+      <Example>
+        <Description />
+        <File />
+      </Example>
+    </MetaInfo>
+    <Events>
+      <Enabled value="True" />
+    </Events>
+  </Properties>
+</AlteryxDocument>

--- a/ContinuumProcessRunner/AlteryxTesting/ProcessRunnerTest_HighLoad.yxmd
+++ b/ContinuumProcessRunner/AlteryxTesting/ProcessRunnerTest_HighLoad.yxmd
@@ -1,0 +1,126 @@
+<?xml version="1.0"?>
+<AlteryxDocument yxmdVer="2018.2">
+  <Nodes>
+    <Node ToolID="2">
+      <GuiSettings Plugin="AlteryxBasePluginsGui.TextInput.TextInput">
+        <Position x="54" y="54" />
+      </GuiSettings>
+      <Properties>
+        <Configuration>
+          <NumRows value="1" />
+          <Fields>
+            <Field name="ColA" />
+            <Field name="ColB" />
+          </Fields>
+          <Data>
+            <r>
+              <c>C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe</c>
+              <c>get-eventlog -logname "Application" -newest 10000 | convertto-csv</c>
+            </r>
+          </Data>
+        </Configuration>
+        <Annotation DisplayMode="0">
+          <Name />
+          <DefaultAnnotationText />
+          <Left value="False" />
+        </Annotation>
+      </Properties>
+      <EngineSettings EngineDll="AlteryxBasePluginsEngine.dll" EngineDllEntryPoint="AlteryxTextInput" />
+    </Node>
+    <Node ToolID="4">
+      <GuiSettings Plugin="AlteryxBasePluginsGui.BrowseV2.BrowseV2">
+        <Position x="354" y="54" />
+      </GuiSettings>
+      <Properties>
+        <Configuration>
+          <TempFile>C:\Users\User\AppData\Local\Temp\Engine_12932_a7d6f760ca01431c9c4e6845994ffbcd_\Engine_6712_ba51fec56d274b4182ad3623c2887c18_.yxdb</TempFile>
+          <TempFileDataProfiling />
+          <Layout>
+            <ViewMode>Single</ViewMode>
+            <ViewSize value="100" />
+            <View1>
+              <DefaultTab>Profile</DefaultTab>
+              <Hints>
+                <Table />
+              </Hints>
+            </View1>
+            <View2 />
+          </Layout>
+        </Configuration>
+        <Annotation DisplayMode="0">
+          <Name />
+          <DefaultAnnotationText />
+          <Left value="False" />
+        </Annotation>
+      </Properties>
+      <EngineSettings EngineDll="AlteryxBasePluginsEngine.dll" EngineDllEntryPoint="AlteryxBrowseV2" />
+    </Node>
+    <Node ToolID="5">
+      <GuiSettings Plugin="ContinuumProcessRunner.ProcessRunner">
+        <Position x="210" y="54" />
+      </GuiSettings>
+      <Properties>
+        <Configuration>
+          <ExePathField>ColA</ExePathField>
+          <StdOutField>ProcessRunnerStdOut</StdOutField>
+          <RetCodeField>ProcessRunnerReturnCode</RetCodeField>
+          <ExceptionField>ProcessRunnerException</ExceptionField>
+        </Configuration>
+        <Annotation DisplayMode="0">
+          <Name />
+          <DefaultAnnotationText>ProcessRunner</DefaultAnnotationText>
+          <Left value="False" />
+        </Annotation>
+      </Properties>
+      <EngineSettings EngineDll="ContinuumProcessRunner.dll" EngineDllEntryPoint=".Net:ContinuumProcessRunner.ProcessRunnerNetPlugin" />
+    </Node>
+  </Nodes>
+  <Connections>
+    <Connection>
+      <Origin ToolID="2" Connection="Output" />
+      <Destination ToolID="5" Connection="Input" />
+    </Connection>
+    <Connection>
+      <Origin ToolID="5" Connection="Output" />
+      <Destination ToolID="4" Connection="Input" />
+    </Connection>
+  </Connections>
+  <Properties>
+    <Memory default="True" />
+    <GlobalRecordLimit value="0" />
+    <TempFiles default="True" />
+    <Annotation on="True" includeToolName="False" />
+    <ConvErrorLimit value="10" />
+    <ConvErrorLimit_Stop value="False" />
+    <CancelOnError value="False" />
+    <DisableBrowse value="False" />
+    <EnablePerformanceProfiling value="False" />
+    <DisableAllOutput value="False" />
+    <ShowAllMacroMessages value="False" />
+    <ShowConnectionStatusIsOn value="True" />
+    <ShowConnectionStatusOnlyWhenRunning value="True" />
+    <ZoomLevel value="0" />
+    <LayoutType>Horizontal</LayoutType>
+    <MetaInfo>
+      <NameIsFileName value="True" />
+      <Name>ProcessRunnerTest_HighLoad</Name>
+      <Description />
+      <RootToolName />
+      <ToolVersion />
+      <ToolInDb value="False" />
+      <CategoryName />
+      <SearchTags />
+      <Author />
+      <Company />
+      <Copyright />
+      <DescriptionLink actual="" displayed="" />
+      <Example>
+        <Description />
+        <File />
+      </Example>
+    </MetaInfo>
+    <Events>
+      <Enabled value="True" />
+    </Events>
+  </Properties>
+</AlteryxDocument>

--- a/ContinuumProcessRunner/AlteryxTesting/ProcessRunnerTest_Simple.bak
+++ b/ContinuumProcessRunner/AlteryxTesting/ProcessRunnerTest_Simple.bak
@@ -1,0 +1,166 @@
+<?xml version="1.0"?>
+<AlteryxDocument yxmdVer="2018.2">
+  <Nodes>
+    <Node ToolID="2">
+      <GuiSettings Plugin="AlteryxBasePluginsGui.TextInput.TextInput">
+        <Position x="54" y="54" />
+      </GuiSettings>
+      <Properties>
+        <Configuration>
+          <NumRows value="7" />
+          <Fields>
+            <Field name="ColA" />
+            <Field name="ColB" />
+            <Field name="ColC" />
+            <Field name="Col D" />
+          </Fields>
+          <Data>
+            <r>
+              <c>C:/users/user/appdata/local/programs/python/python37/python.exe</c>
+              <c>C:/users/user/documents/python/testscriptargs.py</c>
+              <c>49</c>
+              <c>Steve</c>
+            </r>
+            <r>
+              <c>C:/users/user/appdata/local/programs/python/python37/python.exe</c>
+              <c>C:/users/user/documents/python/testscriptexcpts.py</c>
+              <c>50</c>
+              <c>Rors</c>
+            </r>
+            <r>
+              <c>C:/users/user/appdata/local/programs/python/python37/python.exe</c>
+              <c>C:/users/user/documents/python/testscriptlong.py</c>
+              <c>51</c>
+              <c>Craig</c>
+            </r>
+            <r>
+              <c>C:/users/user/appdata/local/programs/python/python37/python.exe</c>
+              <c>C:/users/user/documents/python/testscriptargs.py</c>
+              <c>52</c>
+              <c>Steve Hibbert</c>
+            </r>
+            <r>
+              <c>C:/users/user/appdata/local/programs/python/python37/python.exe</c>
+              <c>C:/users/user/documents/python/testscriptargs.py</c>
+              <c>53</c>
+              <c>"Steve Hibbert"</c>
+            </r>
+            <r>
+              <c>C:\Windows\System32\cmd.exe</c>
+              <c>/c</c>
+              <c>C:\Users\user\documents\batchfiles\mybatch.bat</c>
+              <c>Testing</c>
+            </r>
+            <r>
+              <c>C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe</c>
+              <c>C:\users\user\documents\powershell\myPS.ps1</c>
+              <c>Alpha</c>
+              <c>Beta</c>
+            </r>
+          </Data>
+        </Configuration>
+        <Annotation DisplayMode="0">
+          <Name />
+          <DefaultAnnotationText />
+          <Left value="False" />
+        </Annotation>
+      </Properties>
+      <EngineSettings EngineDll="AlteryxBasePluginsEngine.dll" EngineDllEntryPoint="AlteryxTextInput" />
+    </Node>
+    <Node ToolID="4">
+      <GuiSettings Plugin="AlteryxBasePluginsGui.BrowseV2.BrowseV2">
+        <Position x="354" y="54" />
+      </GuiSettings>
+      <Properties>
+        <Configuration>
+          <TempFile>C:\Users\User\AppData\Local\Temp\Engine_16276_6e7aee8b52df4fef8312f3e65f84b531_\Engine_20348_97da0ebeecb741b49537cbf899ce36b0_.yxdb</TempFile>
+          <TempFileDataProfiling />
+          <Layout>
+            <ViewMode>Single</ViewMode>
+            <ViewSize value="100" />
+            <View1>
+              <DefaultTab>Profile</DefaultTab>
+              <Hints>
+                <Table />
+              </Hints>
+            </View1>
+            <View2 />
+          </Layout>
+        </Configuration>
+        <Annotation DisplayMode="0">
+          <Name />
+          <DefaultAnnotationText />
+          <Left value="False" />
+        </Annotation>
+      </Properties>
+      <EngineSettings EngineDll="AlteryxBasePluginsEngine.dll" EngineDllEntryPoint="AlteryxBrowseV2" />
+    </Node>
+    <Node ToolID="5">
+      <GuiSettings Plugin="ContinuumProcessRunner.ProcessRunner">
+        <Position x="210" y="54" />
+      </GuiSettings>
+      <Properties>
+        <Configuration>
+          <ExePathField>ColA</ExePathField>
+          <StdOutField>ProcessRunnerStdOut</StdOutField>
+          <RetCodeField>ProcessRunnerReturnCode</RetCodeField>
+          <ExceptionField>ProcessRunnerException</ExceptionField>
+        </Configuration>
+        <Annotation DisplayMode="0">
+          <Name />
+          <DefaultAnnotationText>ProcessRunner</DefaultAnnotationText>
+          <Left value="False" />
+        </Annotation>
+      </Properties>
+      <EngineSettings EngineDll="ContinuumProcessRunner.dll" EngineDllEntryPoint=".Net:ContinuumProcessRunner.ProcessRunnerNetPlugin" />
+    </Node>
+  </Nodes>
+  <Connections>
+    <Connection>
+      <Origin ToolID="2" Connection="Output" />
+      <Destination ToolID="5" Connection="Input" />
+    </Connection>
+    <Connection>
+      <Origin ToolID="5" Connection="Output" />
+      <Destination ToolID="4" Connection="Input" />
+    </Connection>
+  </Connections>
+  <Properties>
+    <Memory default="True" />
+    <GlobalRecordLimit value="0" />
+    <TempFiles default="True" />
+    <Annotation on="True" includeToolName="False" />
+    <ConvErrorLimit value="10" />
+    <ConvErrorLimit_Stop value="False" />
+    <CancelOnError value="False" />
+    <DisableBrowse value="False" />
+    <EnablePerformanceProfiling value="False" />
+    <DisableAllOutput value="False" />
+    <ShowAllMacroMessages value="False" />
+    <ShowConnectionStatusIsOn value="True" />
+    <ShowConnectionStatusOnlyWhenRunning value="True" />
+    <ZoomLevel value="0" />
+    <LayoutType>Horizontal</LayoutType>
+    <MetaInfo>
+      <NameIsFileName value="True" />
+      <Name>ProcessRunnerTest</Name>
+      <Description />
+      <RootToolName />
+      <ToolVersion />
+      <ToolInDb value="False" />
+      <CategoryName />
+      <SearchTags />
+      <Author />
+      <Company />
+      <Copyright />
+      <DescriptionLink actual="" displayed="" />
+      <Example>
+        <Description />
+        <File />
+      </Example>
+    </MetaInfo>
+    <Events>
+      <Enabled value="True" />
+    </Events>
+  </Properties>
+</AlteryxDocument>

--- a/ContinuumProcessRunner/AlteryxTesting/ProcessRunnerTest_Simple.yxmd
+++ b/ContinuumProcessRunner/AlteryxTesting/ProcessRunnerTest_Simple.yxmd
@@ -1,0 +1,166 @@
+<?xml version="1.0"?>
+<AlteryxDocument yxmdVer="2018.2">
+  <Nodes>
+    <Node ToolID="2">
+      <GuiSettings Plugin="AlteryxBasePluginsGui.TextInput.TextInput">
+        <Position x="54" y="54" />
+      </GuiSettings>
+      <Properties>
+        <Configuration>
+          <NumRows value="7" />
+          <Fields>
+            <Field name="ColA" />
+            <Field name="ColB" />
+            <Field name="ColC" />
+            <Field name="Col D" />
+          </Fields>
+          <Data>
+            <r>
+              <c>C:/users/user/appdata/local/programs/python/python37/python.exe</c>
+              <c>C:/users/user/documents/python/testscriptargs.py</c>
+              <c>49</c>
+              <c>Steve</c>
+            </r>
+            <r>
+              <c>C:/users/user/appdata/local/programs/python/python37/python.exe</c>
+              <c>C:/users/user/documents/python/testscriptexcpts.py</c>
+              <c>50</c>
+              <c>Rors</c>
+            </r>
+            <r>
+              <c>C:/users/user/appdata/local/programs/python/python37/python.exe</c>
+              <c>C:/users/user/documents/python/testscriptlong.py</c>
+              <c>51</c>
+              <c>Craig</c>
+            </r>
+            <r>
+              <c>C:/users/user/appdata/local/programs/python/python37/python.exe</c>
+              <c>C:/users/user/documents/python/testscriptargs.py</c>
+              <c>52</c>
+              <c>Steve Hibbert</c>
+            </r>
+            <r>
+              <c>C:/users/user/appdata/local/programs/python/python37/python.exe</c>
+              <c>C:/users/user/documents/python/testscriptargs.py</c>
+              <c>53</c>
+              <c>"Steve Hibbert"</c>
+            </r>
+            <r>
+              <c>C:\Windows\System32\cmd.exe</c>
+              <c>/c</c>
+              <c>C:\Users\user\documents\batchfiles\mybatch.bat</c>
+              <c>Testing</c>
+            </r>
+            <r>
+              <c>C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe</c>
+              <c>C:\users\user\documents\powershell\myPS.ps1</c>
+              <c>Alpha</c>
+              <c>Beta</c>
+            </r>
+          </Data>
+        </Configuration>
+        <Annotation DisplayMode="0">
+          <Name />
+          <DefaultAnnotationText />
+          <Left value="False" />
+        </Annotation>
+      </Properties>
+      <EngineSettings EngineDll="AlteryxBasePluginsEngine.dll" EngineDllEntryPoint="AlteryxTextInput" />
+    </Node>
+    <Node ToolID="4">
+      <GuiSettings Plugin="AlteryxBasePluginsGui.BrowseV2.BrowseV2">
+        <Position x="354" y="54" />
+      </GuiSettings>
+      <Properties>
+        <Configuration>
+          <TempFile>C:\Users\User\AppData\Local\Temp\Engine_16276_6e7aee8b52df4fef8312f3e65f84b531_\Engine_20348_97da0ebeecb741b49537cbf899ce36b0_.yxdb</TempFile>
+          <TempFileDataProfiling />
+          <Layout>
+            <ViewMode>Single</ViewMode>
+            <ViewSize value="100" />
+            <View1>
+              <DefaultTab>Profile</DefaultTab>
+              <Hints>
+                <Table />
+              </Hints>
+            </View1>
+            <View2 />
+          </Layout>
+        </Configuration>
+        <Annotation DisplayMode="0">
+          <Name />
+          <DefaultAnnotationText />
+          <Left value="False" />
+        </Annotation>
+      </Properties>
+      <EngineSettings EngineDll="AlteryxBasePluginsEngine.dll" EngineDllEntryPoint="AlteryxBrowseV2" />
+    </Node>
+    <Node ToolID="5">
+      <GuiSettings Plugin="ContinuumProcessRunner.ProcessRunner">
+        <Position x="210" y="54" />
+      </GuiSettings>
+      <Properties>
+        <Configuration>
+          <ExePathField>ColA</ExePathField>
+          <StdOutField>ProcessRunnerStdOut</StdOutField>
+          <RetCodeField>ProcessRunnerReturnCode</RetCodeField>
+          <ExceptionField>ProcessRunnerException</ExceptionField>
+        </Configuration>
+        <Annotation DisplayMode="0">
+          <Name />
+          <DefaultAnnotationText>ProcessRunner</DefaultAnnotationText>
+          <Left value="False" />
+        </Annotation>
+      </Properties>
+      <EngineSettings EngineDll="ContinuumProcessRunner.dll" EngineDllEntryPoint=".Net:ContinuumProcessRunner.ProcessRunnerNetPlugin" />
+    </Node>
+  </Nodes>
+  <Connections>
+    <Connection>
+      <Origin ToolID="2" Connection="Output" />
+      <Destination ToolID="5" Connection="Input" />
+    </Connection>
+    <Connection>
+      <Origin ToolID="5" Connection="Output" />
+      <Destination ToolID="4" Connection="Input" />
+    </Connection>
+  </Connections>
+  <Properties>
+    <Memory default="True" />
+    <GlobalRecordLimit value="0" />
+    <TempFiles default="True" />
+    <Annotation on="True" includeToolName="False" />
+    <ConvErrorLimit value="10" />
+    <ConvErrorLimit_Stop value="False" />
+    <CancelOnError value="False" />
+    <DisableBrowse value="False" />
+    <EnablePerformanceProfiling value="False" />
+    <DisableAllOutput value="False" />
+    <ShowAllMacroMessages value="False" />
+    <ShowConnectionStatusIsOn value="True" />
+    <ShowConnectionStatusOnlyWhenRunning value="True" />
+    <ZoomLevel value="0" />
+    <LayoutType>Horizontal</LayoutType>
+    <MetaInfo>
+      <NameIsFileName value="True" />
+      <Name>ProcessRunnerTest_Simple</Name>
+      <Description />
+      <RootToolName />
+      <ToolVersion />
+      <ToolInDb value="False" />
+      <CategoryName />
+      <SearchTags />
+      <Author />
+      <Company />
+      <Copyright />
+      <DescriptionLink actual="" displayed="" />
+      <Example>
+        <Description />
+        <File />
+      </Example>
+    </MetaInfo>
+    <Events>
+      <Enabled value="True" />
+    </Events>
+  </Properties>
+</AlteryxDocument>

--- a/ContinuumProcessRunner/AlteryxTesting/QueryLogsA.ps1
+++ b/ContinuumProcessRunner/AlteryxTesting/QueryLogsA.ps1
@@ -1,0 +1,1 @@
+get-eventlog -logname "Application" -newest 100 | convertto-csv

--- a/ContinuumProcessRunner/ProcessRunnerUserControl.Designer.cs
+++ b/ContinuumProcessRunner/ProcessRunnerUserControl.Designer.cs
@@ -72,7 +72,7 @@
             this.labelVersion.Name = "labelVersion";
             this.labelVersion.Size = new System.Drawing.Size(38, 12);
             this.labelVersion.TabIndex = 1;
-            this.labelVersion.Text = "(v1.0.1)";
+            this.labelVersion.Text = "(v1.0.2)";
             // 
             // labelHeader
             // 

--- a/ReadMe.MD
+++ b/ReadMe.MD
@@ -299,3 +299,6 @@ Alpha Release
 
 #### v1.0.1
 Beta; Max field size for StdOut and Exception output fields increased from 65535 to 2Gb, allowing 1 billion 2-byte chars.
+
+#### v1.0.2
+Beta; Use StringBuilder to build output to improve high-load performance.  Prior to this change, 10000 records output took 33.7 secs, after this change, 8.9 secs.  Vrrroooom.


### PR DESCRIPTION
BRANCH: 2018-08-16_LT3_PerformanceImprovementWithStringBuilder

CHANGED: ContinuumProcessRunner/ProcessRunnerNetPlugin.cs
 - New member variables added for StdOut, old removed.
 - II_PushRecord() clears StringBuilder, outputs string and clears StringBuilder again at the end.
 - run_OutputReceived() amended to add data to StringBuilder.
 - getArguments() superfluous variable removed.

CHANGED: ContinuumProcessRunner/ProcessRunnerUserControl.Designer.cs
 - Version number updated to 1.0.2

CHANGED: ReadMe.MD
 - Version history updated.

ADDED:
 - ContinuumProcessRunner/AlteryxTesting/ProcessRunnerTest_HighLoad.bak
 - ContinuumProcessRunner/AlteryxTesting/ProcessRunnerTest_HighLoad.yxmd
 - ContinuumProcessRunner/AlteryxTesting/ProcessRunnerTest_Simple.bak
 - ContinuumProcessRunner/AlteryxTesting/ProcessRunnerTest_Simple.yxmd
 - ContinuumProcessRunner/AlteryxTesting/QueryLogsA.ps1