### PR TITLE
Use StringBuilder to compile exceptions output;

### DIFF
--- a/ContinuumProcessRunner/ProcessRunnerUserControl.Designer.cs
+++ b/ContinuumProcessRunner/ProcessRunnerUserControl.Designer.cs
@@ -72,7 +72,7 @@
             this.labelVersion.Name = "labelVersion";
             this.labelVersion.Size = new System.Drawing.Size(38, 12);
             this.labelVersion.TabIndex = 1;
-            this.labelVersion.Text = "(v1.0.3)";
+            this.labelVersion.Text = "(v1.0.4)";
             // 
             // labelHeader
             // 

--- a/ReadMe.MD
+++ b/ReadMe.MD
@@ -307,3 +307,7 @@ Beta; Use StringBuilder to build output to improve high-load performance.  Prior
 Beta; Default working directory for the spawned process changed from this.WorkingDirectory to Environment.SpecialFolder.Personal .
 The previous working directory would be wherever the DLL ran from, which could be Admin restricted.
 The new working directory is the users MyDocuments folder, which the user should have full rights to.
+
+#### v1.0.4
+Beta; Use StringBuilder to build exceptions string, similar to change from v1.0.1 to v1.0.2
+


### PR DESCRIPTION
BRANCH: 2018-09-10_LT3_ExceptionsStringBuilder_v1.0.4

CHANGED: ContinuumProcessRunner/ProcessRunnerNetPlugin.cs
 - Member _exceptions removed.
 - Members _sbExceptions and _sbExceptionsLock added.
 - II_PushRecord() chenged to lock and clear the StringBuilder on start, and lock and ToString() and set record on finish.
 - run_OutputReceived() changed to lock and add exception string to StringBuilder on error.

CHANGED: ContinuumProcessRunner/ProcessRunnerUserControl.Designer.cs
 - Version text changed for new version.

CHANGED: ReadMe.MD
 - Updated for new version notes.